### PR TITLE
Fix readonly patch indexing

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "3.0.100-preview9"
+    "version": "8.0.116"
   }
 }

--- a/src/Sigil/Emit.cs
+++ b/src/Sigil/Emit.cs
@@ -921,7 +921,7 @@ namespace Sigil
                     var update = SigilTuple.Create(elem.Item1 - 1, elem.Item2);
 
                     ReadonlyPatches.Remove(elem);
-                    ReadonlyPatches.Add(elem);
+                    ReadonlyPatches.Add(update);
                 }
             }
         }
@@ -996,7 +996,7 @@ namespace Sigil
                     var update = SigilTuple.Create(elem.Item1 + 1, elem.Item2);
 
                     ReadonlyPatches.Remove(elem);
-                    ReadonlyPatches.Add(elem);
+                    ReadonlyPatches.Add(update);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix bug when adjusting indices for readonly patch inserts
- update global.json to a modern .NET SDK so tests can run

## Testing
- `dotnet test` *(fails: Nerdbank.GitVersioning task missing)*

------
https://chatgpt.com/codex/tasks/task_e_68401ff699a883228668e5035f532677