### PR TITLE
Ensure allocated memory freed in pointer tests

### DIFF
--- a/tests/SigilTests/Add.NonGeneric.cs
+++ b/tests/SigilTests/Add.NonGeneric.cs
@@ -20,12 +20,16 @@ namespace SigilTests
             var d1 = (PointerToPointerDelegate)e1.CreateDelegate(typeof(PointerToPointerDelegate));
 
             int* ptr1 = (int*)Marshal.AllocHGlobal(64);
+            try
+            {
+                var ptr2 = d1(4, ptr1);
 
-            var ptr2 = d1(4, ptr1);
-
-            Marshal.FreeHGlobal((IntPtr)ptr1);
-
-            Assert.Equal(((int)ptr1) + 4, (int)ptr2);
+                Assert.Equal(((int)ptr1) + 4, (int)ptr2);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal((IntPtr)ptr1);
+            }
         }
 
         [Fact]

--- a/tests/SigilTests/Add.cs
+++ b/tests/SigilTests/Add.cs
@@ -22,12 +22,16 @@ namespace SigilTests
             var d1 = e1.CreateDelegate();
 
             int* ptr1 = (int*)Marshal.AllocHGlobal(64);
+            try
+            {
+                var ptr2 = d1(4, ptr1);
 
-            var ptr2 = d1(4, ptr1);
-
-            Marshal.FreeHGlobal((IntPtr)ptr1);
-
-            Assert.Equal(((int)ptr1) + 4, (int)ptr2);
+                Assert.Equal(((int)ptr1) + 4, (int)ptr2);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal((IntPtr)ptr1);
+            }
         }
 
         private delegate void ByRefToByRefDelegate(ref int a, int b, ref int c);


### PR DESCRIPTION
## Summary
- add try/finally around Marshal.AllocHGlobal usage in `Add` tests

## Testing
- `dotnet restore`
- `dotnet test --verbosity minimal` *(fails: 33 failed, 515 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68402b170da88322962a04dbb7b5d6ae