### PR TITLE
Use latest xUnit runner

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- target .NET 8 in tests with an up to date xUnit runner

## Testing
- `dotnet restore Sigil.sln`
- `dotnet test Sigil.sln --no-build --verbosity normal` *(fails: 33 tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684031b3c2d48322be5dc64aaf36b255