### PR TITLE
Fix NuGet mapping and clean test props

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,14 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="Microsoft.*" />
+      <package pattern="xunit*" />
+      <package pattern="Nerdbank.*" />
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,9 +5,5 @@
     <xUnitVersion>2.9.3</xUnitVersion>
   </PropertyGroup>
   
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
-  </ItemGroup>
+  <!-- Test dependencies are declared in individual test project files -->
 </Project>


### PR DESCRIPTION
## Summary
- map packages to nuget.org in nuget.config
- remove global test dependencies in `Directory.Build.props`

## Testing
- `dotnet restore`
- `dotnet test ./tests/SigilTests/SigilTests.csproj` *(fails: InvalidProgramException & failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840391b83588322876b89e093abfc91