### PR TITLE
Fix duplicate test package references

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,12 +2,5 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <xUnitVersion>2.9.3</xUnitVersion>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="$(xUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- prune old dependencies in `tests/Directory.Build.props`
- keep the updated package references only in `SigilTests.csproj`

## Testing
- `dotnet test --no-build tests/SigilTests/SigilTests.csproj` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403978bea08322b5f294e2b76ce7bc